### PR TITLE
Normalize highlight formatting

### DIFF
--- a/app/dashboard/[id]/page.tsx
+++ b/app/dashboard/[id]/page.tsx
@@ -44,6 +44,12 @@ const safelyParseJSON = (jsonString: string) => {
   }
 };
 
+// Normalize highlight text by ensuring each timestamp starts on a new line
+const enforceLineBreaks = (text: string) => {
+  const withBreaks = text.replace(/\s*(\[\d{2}:\d{2}:\d{2}\])/g, '\n$1');
+  return withBreaks.replace(/^\n+/, '');
+};
+
 // Debug interface to track application state
 interface DebugState {
   appVersion: string;
@@ -331,7 +337,7 @@ export default function DashboardPage() {
               originalFileSize: podcast.fileSize,
               summary: analysis.summary || 'Summary not available.',
               translation: analysis.translation || 'Translation not available.',
-              fullTextHighlights: analysis.highlights || 'Highlights not available.',
+              fullTextHighlights: enforceLineBreaks(analysis.highlights || 'Highlights not available.'),
               processedAt: analysis.processedAt,
             });
             setIsLoading(false);
@@ -479,7 +485,7 @@ export default function DashboardPage() {
               return resolve({
                 summary,
                 translation,
-                fullTextHighlights: highlights,
+                fullTextHighlights: enforceLineBreaks(highlights),
                 processedAt: new Date().toISOString()
               });
             }
@@ -556,7 +562,7 @@ export default function DashboardPage() {
                       } : null);
                       break;
                     case 'highlight_final_result':
-                      highlights = eventData.content;
+                      highlights = enforceLineBreaks(eventData.content);
                       setData(prevData => prevData ? {
                         ...prevData,
                         fullTextHighlights: highlights,
@@ -567,7 +573,7 @@ export default function DashboardPage() {
                       if (eventData.finalResults) {
                         summary = eventData.finalResults.summary;
                         translation = eventData.finalResults.translation;
-                        highlights = eventData.finalResults.highlights;
+                        highlights = enforceLineBreaks(eventData.finalResults.highlights);
                         
                         console.log(`[DEBUG] Final results received - summary: ${summary?.length} chars, translation: ${translation?.length} chars`);
                         


### PR DESCRIPTION
## Summary
- normalize highlight display by inserting newlines before each timestamp
- update highlight handling to apply the normalization when reading from the database and on final streaming results

## Testing
- `npm test` *(fails: Jest encountered unexpected tokens)*

------
https://chatgpt.com/codex/tasks/task_e_6886ed2126948330bb4aee08f7054798