### PR TITLE
Fix dashboard bilingual summary fallback

### DIFF
--- a/__tests__/dashboard/DashboardPage.test.tsx
+++ b/__tests__/dashboard/DashboardPage.test.tsx
@@ -263,6 +263,52 @@ describe('DashboardPage language modes', () => {
     });
   });
 
+  test('splits marker-delimited bilingual content stored in the Chinese summary field', async () => {
+    const payloadWithCombinedZhField = JSON.parse(JSON.stringify(analysisPayload));
+    payloadWithCombinedZhField.data.analysis.summaryZh = `<<<SUMMARY_EN>>>
+# English Summary
+## Key Takeaways
+- English combined fallback
+
+<<<SUMMARY_ZH>>>
+# 中文总结
+## 核心观点
+- 中文拆分结果`;
+    payloadWithCombinedZhField.data.analysis.summaryEn = '';
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/analysis/')) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => payloadWithCombinedZhField,
+          text: async () => JSON.stringify(payloadWithCombinedZhField),
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({ success: false }),
+        text: async () => '',
+      } as Response;
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('中文拆分结果');
+      expect(document.body).not.toHaveTextContent('<<<SUMMARY_EN>>>');
+      expect(document.body).not.toHaveTextContent('English combined fallback');
+    });
+
+    await userEvent.click(screen.getByText('English'));
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('English combined fallback');
+    });
+  });
+
   test('renders hint mode with interactive dictionary links on english full text', async () => {
     render(<DashboardPage />);
 

--- a/app/dashboard/[id]/page.tsx
+++ b/app/dashboard/[id]/page.tsx
@@ -211,6 +211,31 @@ const extractLegacyBilingualSummary = (summaryRaw: string): { zh: string; en: st
   };
 };
 
+
+const resolveDashboardSummaries = (analysis: { summary?: string | null; summaryZh?: string | null; summaryEn?: string | null }): { summaryZh: string; summaryEn: string } => {
+  const legacyFromCombined = extractLegacyBilingualSummary(analysis.summary || '');
+  const splitFromZhField = extractLegacyBilingualSummary(analysis.summaryZh || '');
+  const splitFromEnField = extractLegacyBilingualSummary(analysis.summaryEn || '');
+
+  const summaryZh =
+    splitFromZhField.zh ||
+    legacyFromCombined.zh ||
+    analysis.summaryZh ||
+    analysis.summary ||
+    'Summary not available.';
+  const summaryEn =
+    splitFromEnField.en ||
+    splitFromZhField.en ||
+    analysis.summaryEn ||
+    legacyFromCombined.en ||
+    'English summary not available.';
+
+  return {
+    summaryZh: normalizeMarkdownOutput(summaryZh),
+    summaryEn: normalizeMarkdownOutput(summaryEn),
+  };
+};
+
 const EMPHASIS_EXCLUDED_KEYWORDS = new Set([
   'youtube',
   'transcript',
@@ -1448,7 +1473,7 @@ export default function DashboardPage() {
           if (isProcessed && analysis && podcast) {
             // 数据库中有完整的分析结果
             dashboardDebugLog('[DEBUG] 从数据库加载完整分析结果');
-            const legacySummary = extractLegacyBilingualSummary(analysis.summary || '');
+            const resolvedSummaries = resolveDashboardSummaries(analysis);
             const normalizedFullTextBilingualJson = normalizeFullTextBilingualPayload(analysis.fullTextBilingualJson);
             const normalizedSummaryBilingualJson = normalizeSummaryBilingualPayload(analysis.summaryBilingualJson);
             const loadedData: ProcessedData = {
@@ -1456,12 +1481,8 @@ export default function DashboardPage() {
               originalFileName: podcast.originalFileName || 'Transcript',
               originalFileSize: podcast.fileSize || '-',
               blobUrl: podcast.blobUrl ?? null,
-              summaryZh: normalizeMarkdownOutput(
-                analysis.summaryZh || legacySummary.zh || analysis.summary || 'Summary not available.'
-              ),
-              summaryEn: normalizeMarkdownOutput(
-                analysis.summaryEn || legacySummary.en || 'English summary not available.'
-              ),
+              summaryZh: resolvedSummaries.summaryZh,
+              summaryEn: resolvedSummaries.summaryEn,
               translation: normalizeMarkdownOutput(
                 enforceLineBreaks(analysis.translation || 'Translation not available.')
               ),
@@ -1510,7 +1531,7 @@ export default function DashboardPage() {
             // 数据库中有播客信息但没有分析结果，需要处理
             dashboardDebugLog('[DEBUG] 数据库中有播客信息但无分析结果，开始处理');
             setData(prev => {
-              const legacySummary = extractLegacyBilingualSummary(analysis?.summary || '');
+              const resolvedSummaries = analysis ? resolveDashboardSummaries(analysis) : null;
               const normalizedFullTextBilingualJson = normalizeFullTextBilingualPayload(analysis?.fullTextBilingualJson);
               const normalizedSummaryBilingualJson = normalizeSummaryBilingualPayload(analysis?.summaryBilingualJson);
               return ({
@@ -1518,11 +1539,11 @@ export default function DashboardPage() {
               originalFileName: podcast.originalFileName || 'Transcript',
               originalFileSize: podcast.fileSize || '-',
               blobUrl: podcast.blobUrl ?? prev?.blobUrl ?? null,
-              summaryZh: analysis?.summaryZh || analysis?.summary
-                ? normalizeMarkdownOutput(analysis?.summaryZh || legacySummary.zh || analysis?.summary || '')
+              summaryZh: resolvedSummaries
+                ? resolvedSummaries.summaryZh
                 : prev?.summaryZh || '',
-              summaryEn: analysis?.summaryEn || analysis?.summary
-                ? normalizeMarkdownOutput(analysis?.summaryEn || legacySummary.en || '')
+              summaryEn: resolvedSummaries
+                ? resolvedSummaries.summaryEn
                 : prev?.summaryEn || '',
               translation: analysis?.translation
                 ? normalizeMarkdownOutput(


### PR DESCRIPTION
### Motivation

- The dashboard could render English content in the Chinese tab when legacy/combined bilingual summaries (with `<<<SUMMARY_EN>>>`/`<<<SUMMARY_ZH>>>` markers) were stored in the `summaryZh` field, so the UI must reliably extract true Chinese and English pieces from mixed inputs.

### Description

- Add `resolveDashboardSummaries(...)` to unify and prefer properly split `summaryZh`/`summaryEn` values and to extract marker-delimited bilingual content from `summary`, `summaryZh`, or `summaryEn` when necessary.
- Use the resolved `summaryZh`/`summaryEn` for both fully processed and partially loaded dashboard states, replacing previous ad-hoc fallbacks in `app/dashboard/[id]/page.tsx`.
- Add a regression test `splits marker-delimited bilingual content stored in the Chinese summary field` to `__tests__/dashboard/DashboardPage.test.tsx` that verifies the Chinese tab shows only Chinese and the English tab shows the English fallback.

### Testing

- Ran `npm run type-check` which completed successfully.
- Ran component tests with `npm run test:components -- --runInBand` which passed (`__tests__/dashboard` suites passed).
- Ran the updated integration test file with `npx jest __tests__/dashboard/DashboardPage.test.tsx --runInBand` which passed all tests in that suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fce0eb3188330a18a268a35d42b86)