### PR TITLE
Document homepage production performance results

### DIFF
--- a/docs/performance/home-baseline.md
+++ b/docs/performance/home-baseline.md
@@ -4,8 +4,8 @@
 
 - Measurement date: 2026-07-10
 - Production URL: <https://podsum.cc/>
-- Production Worker version: `66`
-- Production build ID: `iOx-Zzm1IIsSrblLN2Ywn`
+- Production Worker version: `75e53f8f-412e-436b-9e15-6ac88f0b4708`
+- Production build ID: `Y6ntilBTo4j2MxYgngQRk`
 - Device profile: PageSpeed Insights/Lighthouse mobile emulation for the confirmed baseline; `Pixel 5` for `perf:home`
 - Repeat rule: run five cold mobile measurements in fresh browser contexts and compare the median; the warm measurement is diagnostic only
 - PageSpeed report: [PodSum mobile report](https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fpodsum.cc%2F&form_factor=mobile)
@@ -53,9 +53,30 @@ Cloudflare Browser Rendering independently confirmed 12 public cards in the rend
 
 The Preview database needed the existing additive `0002_add_source_published_at.sql` migration before it could render its existing public records. This migration was approved and applied only to D1 database `podsum-d1-preview`; counts stayed at 58 podcasts, 53 public podcasts, 55 analyses, and 50 public podcasts with analyses. No R2 binding, production route, cron, production D1 migration, or production Worker mutation occurred.
 
-The local network intercepted `*.workers.dev` TLS with a mismatched certificate, so local `curl`, `perf:home`, `perf:lab`, and the local visual verifier could not produce valid live Preview results. The five external Lighthouse runs and Cloudflare's independent remote browser are the acceptance evidence; the failed curl traces are retained under `output/performance/task-6b/ttfb/`. Because external server response and LCP passed with wide margin, the direct public snapshot-to-D1 loader is retained and no incremental-cache R2 or revalidation queue is introduced.
+The local network intercepted `*.workers.dev` TLS with a mismatched certificate, so local `curl`, `perf:home`, `perf:lab`, and the local visual verifier could not produce valid live Preview results. The five external Lighthouse runs and Cloudflare's independent remote browser are the acceptance evidence; the failed curl traces are retained under `output/performance/task-6b/ttfb/`. At this stage the direct public snapshot-to-D1 loader was retained. The production follow-up below supersedes that decision after the first production Lighthouse batch exposed slower uncached server response times.
 
 Evidence is under `output/performance/task-6b/postfix-psi/` and `output/performance/task-6b/browser-rendering/`; the full execution ledger is `.superpowers/sdd/task-6b-report.md`. Based on this Preview evidence, `performance-budget.json` now caps homepage requests at 24, transfer at 256,000 B, LCP at 2,500 ms, and TBT at 200 ms. The root JavaScript Brotli ceiling remains 122,880 B because the verified build is 115,130 B and would not fit the originally proposed 112,640 B ceiling.
+
+## Production release and cache follow-up
+
+PRs [#11](https://github.com/chenzixin1/PodcastSummarizer/pull/11) and [#12](https://github.com/chenzixin1/PodcastSummarizer/pull/12) were merged to `main`. The final production deployment is commit `570fba1abb03b6b5067d48e8712a5a75258d677c`, deployment `31831c35-7a21-49b6-aa8f-7d72d5ccd11a`, Worker version `75e53f8f-412e-436b-9e15-6ac88f0b4708`, and build `Y6ntilBTo4j2MxYgngQRk`.
+
+The first production Lighthouse batch after PR #11 had a median LCP of 2,628 ms, above the 2,500 ms hard gate. PR #12 therefore added a 60-second `unstable_cache` around public homepage data, an R2 incremental cache, OpenNext regional cache, and a Durable Object revalidation queue. Authenticated/private homepage data remains outside the shared cache. Preview and Production use separate R2 buckets.
+
+The final five-run production Lighthouse CI batch passed all assertions:
+
+| Metric | Final production median | Five-run range | Result |
+|---|---:|---:|---|
+| Lighthouse mobile Performance | 98 | 83-99 | Pass |
+| Mobile FCP | 1.218 s | 1.179-2.546 s | Pass |
+| Mobile LCP | 2.169 s | 1.441-2.777 s | Pass |
+| Mobile TBT | 5 ms | 4-14 ms | Pass |
+| Mobile CLS | 0.00067 | 0-0.01182 | Pass |
+| Server response | 545 ms | 326-2,577 ms | Diagnostic; one cold/revalidation outlier |
+
+Compared with the failed pre-cache production batch, median LCP improved from 2,628 ms to 2,169 ms (17.5%). `perf:home` independently measured median cold FCP/LCP at 1,048 ms with 14 requests and 210,400 B transferred. Cloudflare Browser Run used five fresh contexts from an external network and measured median TTFB at 86 ms and median FCP/LCP at 639 ms. Its first request was cold at 1,523 ms TTFB; the four cache-hit requests were 70-110 ms. Every run rendered 12 unique waterfall cards and returned HTTP 200.
+
+Live smoke checks confirmed `/BUILD_ID` exactly matches `Y6ntilBTo4j2MxYgngQRk` and the public snapshot endpoint returns 12 records. The final deployment preserves the production D1 and upload R2 bindings and adds only the isolated `podsum-next-cache-production` cache bucket, Worker self-reference, and `NEXT_CACHE_DO_QUEUE` binding.
 
 ## Reproduce the baseline
 


### PR DESCRIPTION
## Summary
- record the final production commit, deployment, Worker version, and build ID
- document the failed pre-cache Lighthouse batch and the passing post-cache batch
- preserve reproducible Lighthouse, perf:home, and external Browser Run evidence

Documentation only; production code is unchanged.